### PR TITLE
Execute database logic without holding the Ruby GVL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lucchetto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0cd244b0e6781fbbf9fe2236c5e450968b0ef3305f18abb0bdb0d83e6e03b4c"
+dependencies = [
+ "lucchetto-macros",
+ "paste",
+ "rb-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "lucchetto-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac00271909cd9447b395319fc847c70355f77ce6d944ddb3f51b403acd260b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "magnus"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +517,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -824,6 +853,7 @@ version = "1.0.0"
 dependencies = [
  "csv",
  "futures-util",
+ "lucchetto",
  "magnus",
  "ruby",
  "serde",
@@ -832,6 +862,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/ext/sql_bulk_import_rs/Cargo.toml
+++ b/ext/sql_bulk_import_rs/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 csv = "1.3"
 futures-util = "0.3"
+lucchetto = "0.4"
 magnus = "0.7"
 ruby = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/ext/sql_bulk_import_rs/src/lib.rs
+++ b/ext/sql_bulk_import_rs/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, error::Error, path::Path};
 
 use csv::Reader;
+use lucchetto::without_gvl;
 use magnus::{define_module, function, prelude::*};
 use tiberius::{Client, ColumnData, Config, TokenRow};
 use tokio::net::TcpStream;
@@ -24,7 +25,13 @@ async fn create_database_connection() -> Result<Client<Compat<TcpStream>>, Box<d
     Ok(client)
 }
 
-#[tokio::main]
+fn import_csv_file_blocking(path: String, reset_table: bool) -> Result<String, Box<dyn Error>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        import_csv_file(path, reset_table).await
+    })
+}
+
 async fn import_csv_file(path: String, reset_table: bool) -> Result<String, Box<dyn Error>> {
     let file_stem = Path::new(&path)
         .file_stem()
@@ -66,7 +73,13 @@ async fn import_csv_file(path: String, reset_table: bool) -> Result<String, Box<
     Ok(safe_table_name)
 }
 
-#[tokio::main]
+fn export_csv_file_blocking(table_name: String, file_path: String) -> Result<(), Box<dyn Error>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        export_csv_file(table_name, file_path).await
+    })
+}
+
 async fn export_csv_file(table_name: String, file_path: String) -> Result<(), Box<dyn Error>> {
     if table_name.is_empty() {
         return Err("Missing required parameter value: table_name".into());
@@ -153,13 +166,38 @@ fn replace_invalid_chars(name: &str) -> String {
     }
 }
 
+#[without_gvl]
+fn import_csv_file_without_gvl(path: String, reset_table: i32) -> String {
+    match import_csv_file_blocking(path, reset_table != 0) {
+        Ok(table_name) => table_name,
+        Err(e) => format!("ERROR: {e}"),
+    }
+}
+
+#[without_gvl]
+fn export_csv_file_without_gvl(table_name: String, file_path: String) -> String {
+    match export_csv_file_blocking(table_name, file_path) {
+        Ok(()) => "SUCCESS".to_string(),
+        Err(e) => format!("ERROR: {e}"),
+    }
+}
 
 fn ruby_import_csv_file(path: String, reset_table: bool) -> Result<String, magnus::Error> {
-    import_csv_file(path, reset_table).map_err(|e| magnus::Error::new(magnus::exception::runtime_error(), e.to_string()))
+    let result = import_csv_file_without_gvl(path, if reset_table { 1 } else { 0 });
+    if result.starts_with("ERROR: ") {
+        Err(magnus::Error::new(magnus::exception::runtime_error(), result.strip_prefix("ERROR: ").unwrap().to_string()))
+    } else {
+        Ok(result)
+    }
 }
 
 fn ruby_export_csv_file(table_name: String, file_path: String) -> Result<(), magnus::Error> {
-    export_csv_file(table_name, file_path).map_err(|e| magnus::Error::new(magnus::exception::runtime_error(), e.to_string()))
+    let result = export_csv_file_without_gvl(table_name, file_path);
+    if result.starts_with("ERROR: ") {
+        Err(magnus::Error::new(magnus::exception::runtime_error(), result.strip_prefix("ERROR: ").unwrap().to_string()))
+    } else {
+        Ok(())
+    }
 }
 
 #[magnus::init]

--- a/spec/benchmarks_spec.rb
+++ b/spec/benchmarks_spec.rb
@@ -1,13 +1,36 @@
 require 'benchmark'
 
+def spinner
+  return if ENV['CI']
+
+  Thread.new do
+    chars = ['|', '/', '-', '\\']
+    i = 0
+    loop do
+      print "\r#{chars[i]} "
+      $stdout.flush
+      sleep 0.05
+      i = (i + 1) % chars.length
+    end
+  end
+end
 RSpec.describe 'Benchmark Tests', :benchmark do
+
   it 'benchmarks importing a CSV file with a million rows' do
+    spinner
+
+    puts "Generating CSV file..."
     import_csv_file_path = generate_csv_file(10, 1_000_000)
 
+    puts "Starting import..."
     elapsed_time = Benchmark.realtime do
-      SQLBulkImport.import_csv_file import_csv_file_path, true
+      t = Thread.new do
+        SQLBulkImport.import_csv_file import_csv_file_path, true
+      end
+      t.join
     end
 
+    puts "Done"
     puts "Importing a CSV with a million rows took #{elapsed_time.round(2)} seconds (#{(1_000_000 / elapsed_time).round(2)} rows/sec)"
   ensure
     FileUtils.rm_f import_csv_file_path


### PR DESCRIPTION
Since the database logic isn't doing anything with Ruby, it also doesn't need to hold the Ruby GVL. Therefore, we can improve things by releasing the GVL

before (spinner paused)

https://github.com/user-attachments/assets/73e6fc7e-46f3-4ed6-a8b5-7a67c80b14d5 

after (spinner keeps spinning)

https://github.com/user-attachments/assets/edbd7fe4-9d38-46ba-bfa5-bc287093e8f7

It would be nice to have a progress callback as well, but not blocking other threads is more important.